### PR TITLE
Reverting ArgErr in the hope it fixes 'wrong argument count'

### DIFF
--- a/s3.go
+++ b/s3.go
@@ -438,7 +438,7 @@ func (s3 *S3) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		var value string
 
 		if !d.Args(&value) {
-			return d.ArgErr()
+			continue;
 		}
 
 		switch key {


### PR DESCRIPTION
This fixed the error

```
Error: adapting config using caddyfile: parsing caddyfile tokens for 'storage': wrong argument count or unexpected line ending after 's3', at Caddyfile:19
```

for me, which was reported in #16 .

I have no clue whether this is the right way to fix this, but it reverts that line to before the last change.
