### PR TITLE
Add environment variable support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,23 @@ This library allows you to use any S3-compatible provider as key/certificate sto
 
 If both `host` and `endpoint` are specified, an error is reported.
 
+## Environment Variables
+
+The following configuration options can also be set using environment variables. The value in the Caddyfile will 
+take precedence over the corresponding environment variable. 
+
+| Configuration Option | Environment Variable |
+|---------------------|---------------------|
+| `endpoint` | `CERTMAGIC_S3_ENDPOINT` |
+| `bucket` | `CERTMAGIC_S3_BUCKET` |
+| `region` | `CERTMAGIC_S3_REGION` |
+| `access_key` | `CERTMAGIC_S3_ACCESS_KEY` |
+| `secret_key` | `CERTMAGIC_S3_SECRET_KEY` |
+| `profile` | `CERTMAGIC_S3_PROFILE` |
+| `role_arn` | `CERTMAGIC_S3_ROLE_ARN` |
+| `prefix` | `CERTMAGIC_S3_PREFIX` |
+| `encryption_key` | `CERTMAGIC_S3_ENCRYPTION_KEY` |
+
 ## What is an S3-compatible service?
 
 Any service must support the following:

--- a/s3.go
+++ b/s3.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"io/fs"
 	"net/http"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -57,6 +58,18 @@ func init() {
 
 func (s3 *S3) Provision(ctx caddy.Context) error {
 	s3.Logger = ctx.Logger(s3)
+
+	s3.loadFromEnv()
+
+	if s3.Bucket == "" {
+		return errors.New("bucket is required")
+	}
+	if s3.Host != "" && s3.Endpoint != "" {
+		return errors.New("cannot specify both 'host' and 'endpoint' options")
+	}
+	if s3.EncryptionKey != "" && len(s3.EncryptionKey) != 32 {
+		return fmt.Errorf("encryption_key must be exactly 32 bytes, got %d", len(s3.EncryptionKey))
+	}
 
 	if s3.Host != "" {
 		s3.Logger.Info("Using deprecated 'host' option, consider switching to 'endpoint'",
@@ -438,6 +451,36 @@ func parseBool(value string) (bool, error) {
 	return strconv.ParseBool(value)
 }
 
+func (s3 *S3) loadFromEnv() {
+	if s3.Endpoint == "" {
+		s3.Endpoint = os.Getenv("CERTMAGIC_S3_ENDPOINT")
+	}
+	if s3.Bucket == "" {
+		s3.Bucket = os.Getenv("CERTMAGIC_S3_BUCKET")
+	}
+	if s3.Region == "" {
+		s3.Region = os.Getenv("CERTMAGIC_S3_REGION")
+	}
+	if s3.AccessKey == "" {
+		s3.AccessKey = os.Getenv("CERTMAGIC_S3_ACCESS_KEY")
+	}
+	if s3.SecretKey == "" {
+		s3.SecretKey = os.Getenv("CERTMAGIC_S3_SECRET_KEY")
+	}
+	if s3.Profile == "" {
+		s3.Profile = os.Getenv("CERTMAGIC_S3_PROFILE")
+	}
+	if s3.RoleARN == "" {
+		s3.RoleARN = os.Getenv("CERTMAGIC_S3_ROLE_ARN")
+	}
+	if s3.Prefix == "" {
+		s3.Prefix = os.Getenv("CERTMAGIC_S3_PREFIX")
+	}
+	if s3.EncryptionKey == "" {
+		s3.EncryptionKey = os.Getenv("CERTMAGIC_S3_ENCRYPTION_KEY")
+	}
+}
+
 func (s3 *S3) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 	for d.Next() {
 		key := d.Val()
@@ -473,9 +516,6 @@ func (s3 *S3) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		case "prefix":
 			s3.Prefix = value
 		case "encryption_key":
-			if value != "" && len(value) != 32 {
-				return d.Errf("encryption_key must be exactly 32 bytes, got %d", len(value))
-			}
 			s3.EncryptionKey = value
 		case "use_path_style":
 			parsed, err := parseBool(value)
@@ -495,13 +535,6 @@ func (s3 *S3) UnmarshalCaddyfile(d *caddyfile.Dispenser) error {
 		s3.Prefix = "acme"
 	}
 
-	if s3.Bucket == "" {
-		return d.Err("bucket is required")
-	}
-
-	if s3.Host != "" && s3.Endpoint != "" {
-		return d.Err("cannot specify both 'host' and 'endpoint' options")
-	}
 	if s3.Host != "" && s3.Endpoint == "" {
 		s3.Endpoint = "https://" + s3.Host
 	}


### PR DESCRIPTION
Hi @techknowlogick, this PR adds environment variable support. It would be nice to be able to get some of the configuration values, especially secrets, straight from environment variables. This is especially important for users with JSON configs, because the standard `{env.XXX}` notation does not seem to work for the encryption key. 


This PR:

- adds environment variable loading in `Provision(ctx caddy.Context)` so that it works for not only Caddyfiles but also JSON configs
- moves config validation to `Provision(ctx caddy.Context)` so that it can be applied to both Caddyfiles and JSON configs


**Note**: I didn't move any of the default configuration setting (such as for the prefix) in `UnmarshalCaddyfile(d *caddyfile.Dispenser)` because that could break things for JSON config users. 
